### PR TITLE
constructors as functions depricated

### DIFF
--- a/articles/blockchain/workbench/create-app.md
+++ b/articles/blockchain/workbench/create-app.md
@@ -275,7 +275,7 @@ Add the constructor function to your contract in your `HelloBlockchain.sol` smar
 
 ```
     // constructor function
-    function HelloBlockchain(string message) public
+    constructor(string message) public
     {
         Requestor = msg.sender;
         RequestMessage = message;


### PR DESCRIPTION
Fixes warning about defining constructors as functions with the same name as the contract.